### PR TITLE
Add sample trust graph logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/trustgraph_logs/lounge_001_trustgraph.jsonl
+++ b/trustgraph_logs/lounge_001_trustgraph.jsonl
@@ -1,0 +1,2 @@
+{"timestamp": "2025-07-28T18:08:27.633460", "lounge_id": "lounge_001", "trigger": "drift", "context": {"session_id": "sess-001", "user_id": "user-001", "base_flavor": "mint"}}
+{"timestamp": "2025-07-28T18:08:27.633767", "lounge_id": "lounge_001", "trigger": "loyalty", "context": {"session_id": "sess-001", "user_id": "user-001", "base_flavor": "mint"}}


### PR DESCRIPTION
## Summary
- add a sample trustgraph log for `lounge_001`
- ignore Python cache files

## Testing
- `python - <<'PY'
from reflex_webhook_listener import update_trust_graph
update_trust_graph("lounge_001", "drift", {"session_id": "sess-001", "user_id": "user-001", "base_flavor": "mint"})
update_trust_graph("lounge_001", "loyalty", {"session_id": "sess-001", "user_id": "user-001", "base_flavor": "mint"})
PY`

------
https://chatgpt.com/codex/tasks/task_e_6887bb61d97c8330b4ba1b4b0970ee64