### PR TITLE
Add placeholder reflex scripts

### DIFF
--- a/REFLEX_DEPLOYMENT.md
+++ b/REFLEX_DEPLOYMENT.md
@@ -1,1 +1,13 @@
-docs: add Reflex Deployment Manifest
+# Reflex Deployment Manifest
+
+This repository hosts minimal scripts used by Hookah+ POS to test Reflex workflows.
+
+## Available scripts
+
+- `reflex_webhook_listener.py` – Flask endpoint that routes webhook triggers to local scripts.
+- `flavor_sync.py` – placeholder script. It currently logs the lounge ID passed to it.
+- `reflex_session.py` – placeholder script. It logs the user and base flavor supplied.
+
+These placeholders ensure the webhook listener does not fail even when the real
+business logic is not yet implemented. Replace them with actual implementations
+as the project evolves.

--- a/flavor_sync.py
+++ b/flavor_sync.py
@@ -1,0 +1,12 @@
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+    logging.info("flavor_sync placeholder executed with args: %s", sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/reflex_session.py
+++ b/reflex_session.py
@@ -1,0 +1,18 @@
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+    user_id = sys.argv[1] if len(sys.argv) > 1 else None
+    base_flavor = sys.argv[2] if len(sys.argv) > 2 else None
+    logging.info(
+        "reflex_session placeholder executed for user %s with base flavor %s",
+        user_id,
+        base_flavor,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `flavor_sync.py` and `reflex_session.py` with basic logging
- document scripts in `REFLEX_DEPLOYMENT.md`

## Testing
- `python -m py_compile reflex_webhook_listener.py flavor_sync.py reflex_session.py`


------
https://chatgpt.com/codex/tasks/task_e_688812fe7af0833095c9ad18eef85a12