### PR TITLE
Add Reflex UI commands and netlify config

### DIFF
--- a/codex_cmd_launcher.py
+++ b/codex_cmd_launcher.py
@@ -13,6 +13,17 @@ def cmd_dispatch(command: str):
     elif command == "cmd.deployReflexWebhook()":
         print("⚙️ Starting Reflex Webhook listener (mock mode)...")
         os.system("python reflex_webhook_listener.py")
+    elif command == "cmd.deployReflexUI()":
+        print("🚀 Deploying Reflexive UI...")
+        subprocess.run(["python", "../Hookahplus/cmd_dispatcher.py", "deployReflexUI"])
+    elif command.startswith("cmd.renderReflexLoyalty(") and command.endswith(")"):
+        user_id = command[len("cmd.renderReflexLoyalty("):-1]
+        user_id = user_id.strip("'\"")
+        print(f"🎯 Rendering Reflex loyalty for {user_id}...")
+        subprocess.run(["python", "../Hookahplus/cmd_dispatcher.py", "renderReflexLoyalty", user_id])
+    elif command == "cmd.injectReflexHeatmap()":
+        print("🔥 Injecting Reflex Heatmap...")
+        subprocess.run(["python", "../Hookahplus/cmd_dispatcher.py", "injectReflexHeatmap"])
     elif command == "cmd.enableWhisperJournal({ scope: 'loyalty' })":
         print("📘 Loyalty Whisper Journal enabled.")
     else:

--- a/commands/launcher.py
+++ b/commands/launcher.py
@@ -8,6 +8,14 @@ def dispatch_command(cmd):
             enable_whisper_journal(scope="loyalty")
         case "cmd.activateSessionReplay()":
             activate_session_replay()
+        case "cmd.deployReflexUI()":
+            deploy_reflex_ui()
+        case cmd if cmd.startswith("cmd.renderReflexLoyalty(") and cmd.endswith(")"):
+            user_id = cmd[len("cmd.renderReflexLoyalty("):-1]
+            user_id = user_id.strip("'\"")
+            render_reflex_loyalty(user_id)
+        case "cmd.injectReflexHeatmap()":
+            inject_reflex_heatmap()
         case _:
             print(f"[⚠️] Unknown command: {cmd}")
 
@@ -27,6 +35,21 @@ def activate_session_replay():
     # Stub hook for replay events
     with open("src/hooks/useReplay.ts", "w") as f:
         f.write("// Session replay tracking injected")
+
+def deploy_reflex_ui():
+    print("[🚀] Deploying Reflexive UI...")
+    import subprocess
+    subprocess.run(["python", "../Hookahplus/cmd_dispatcher.py", "deployReflexUI"])
+
+def render_reflex_loyalty(user_id):
+    print(f"[🎯] Rendering Reflex loyalty for {user_id}...")
+    import subprocess
+    subprocess.run(["python", "../Hookahplus/cmd_dispatcher.py", "renderReflexLoyalty", user_id])
+
+def inject_reflex_heatmap():
+    print("[🔥] Injecting Reflex Heatmap...")
+    import subprocess
+    subprocess.run(["python", "../Hookahplus/cmd_dispatcher.py", "injectReflexHeatmap"])
 
 if __name__ == "__main__":
     import sys

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,14 @@
 
 [functions]
   directory = "netlify/functions"
+
+
+[build]
+base = "reflexive-ui"
+publish = "reflexive-ui/dist"
+command = "npm run build"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary
- register Reflex UI commands in command dispatchers
- add reflexive UI deployment settings in netlify

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688b82b801fc8330b52cd7b11a859d51